### PR TITLE
Reduce configuration needed for web export

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -9,7 +9,7 @@ custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
-export_path="../../SquashTheCreepsHtml/Squash the Creeps (3D).html"
+export_path="../../exports/web/index.html"
 encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false
@@ -18,10 +18,10 @@ script_export_mode=2
 
 [preset.0.options]
 
-custom_template/debug="/home/scroggo/Engines/godot/bin/web_dlink_debug.zip"
-custom_template/release="/home/scroggo/Engines/godot/bin/web_dlink_release.zip"
+custom_template/debug=""
+custom_template/release=""
 variant/extensions_support=true
-variant/thread_support=false
+variant/thread_support=true
 vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -3,6 +3,6 @@ rustflags = [
     "-C", "link-args=-sSIDE_MODULE=2",
     "-C", "link-args=-pthread", # was -sUSE_PTHREADS=1 in earlier emscripten versions
     "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals",
-    "-C", "llvm-args=-enable-emscripten-cxx-exceptions=0",
     "-Zlink-native-libraries=no",
+    "-Cllvm-args=-enable-emscripten-cxx-exceptions=0"
 ]

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -3,6 +3,7 @@ rustflags = [
     "-C", "link-args=-sSIDE_MODULE=2",
     "-C", "link-args=-pthread", # was -sUSE_PTHREADS=1 in earlier emscripten versions
     "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals",
+    "-C", "llvm-args=-enable-emscripten-cxx-exceptions=0",
     "-Zlink-native-libraries=no",
     "-Clink-arg=-fwasm-exceptions",
     "-Clink-args=-sDISABLE_EXCEPTION_CATCHING=1",
@@ -11,4 +12,3 @@ rustflags = [
     "-Cllvm-args=-enable-emscripten-cxx-exceptions=0",
     "-Cllvm-args=-wasm-enable-sjlj",
 ]
-

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -5,10 +5,4 @@ rustflags = [
     "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals",
     "-C", "llvm-args=-enable-emscripten-cxx-exceptions=0",
     "-Zlink-native-libraries=no",
-    "-Clink-arg=-fwasm-exceptions",
-    "-Clink-args=-sDISABLE_EXCEPTION_CATCHING=1",
-    "-Clink-args=-sEXPORT_ALL=1",
-    "-Clink-args=-sSUPPORT_LONGJMP=wasm",
-    "-Cllvm-args=-enable-emscripten-cxx-exceptions=0",
-    "-Cllvm-args=-wasm-enable-sjlj",
 ]


### PR DESCRIPTION
Following the instructions [provided by the book](https://godot-rust.github.io/book/toolchain/export-web.html), this project was able to run on FF and Chromium _with_ sound.